### PR TITLE
Remove duplicated _posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,7 +35,7 @@ layout: layout
           <li class="prev disabled"><a>上一节</a></li>
         {% endif %}
           <li><a href="{{ BASE_PATH }}{{ category_url }}">回目录</a></li>
-          <li><a href="https://github.com/lingaoqiming/lingaoqiming.github.com/tree/master/_posts/{{page.path}}">编辑本页</a></li>
+          <li><a href="https://github.com/lingaoqiming/lingaoqiming.github.com/tree/master/{{page.path}}">编辑本页</a></li>
         {% if page.next %}
           <li class="next"><a href="{{BASE_PATH}}{{ page.next.url }}" title="{{ page.next.title }}">下一节 </a></li>
         {% else %}


### PR DESCRIPTION
As https://github.com/lingaoqiming/lingaoqiming.github.com/issues/5 suggested, remove duplicated `_posts` as `{{page.path}}` already contains `_posts`.